### PR TITLE
feature: add to timestamp without timezone literal converter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "upils"
-version = "0.3.4"
+version = "0.5.0"
 description = "Unified Python Utils. Requires python 3.10 and later"
 authors = [
     "Aslam Hadi Harsono <aslam.hadi@kumparan.com>",

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -70,6 +70,19 @@ class DTCase(unittest.TestCase):
         self.assertEqual(dt_utc.minute, 0)
         self.assertEqual(dt_utc.second, 15)
 
+    def test_to_timestamp_without_timezone_literal(self):
+        dt = datetime(2023, 1, 1, 7, 0, 0)
+        dt = upils_datetime.to_timestamp_without_timezone_literal(dt)
+        self.assertEqual(dt, "2023-01-01 07:00:00")
+
+        dt = datetime(2023, 1, 1, 7, 1, 50, 999)
+        dt = upils_datetime.to_timestamp_without_timezone_literal(dt)
+        self.assertEqual(dt, "2023-01-01 07:01:50")
+
+        dt = datetime(2023, 1, 1, 12, 15, 30, 999, tzinfo=pytz.UTC)
+        dt = upils_datetime.to_timestamp_without_timezone_literal(dt)
+        self.assertEqual(dt, "2023-01-01 12:15:30")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/upils/datetime.py
+++ b/upils/datetime.py
@@ -39,3 +39,8 @@ def to_timestamp_millis(dt: Union[datetime, str]) -> int:
 
     epoch = datetime.utcfromtimestamp(0)
     return (dt - epoch).total_seconds() * 1000
+
+
+def to_timestamp_without_timezone_literal(date: datetime) -> str:
+    """Return the time in YYYY-MM-DD HH:MM:SS formatted"""
+    return date.strftime("%Y-%m-%d %H:%M:%S")

--- a/upils/datetime.py
+++ b/upils/datetime.py
@@ -42,5 +42,5 @@ def to_timestamp_millis(dt: Union[datetime, str]) -> int:
 
 
 def to_timestamp_without_timezone_literal(date: datetime) -> str:
-    """Return the time in YYYY-MM-DD HH:MM:SS formatted"""
+    """Return the time in %Y-%m-%d %H:%M:%S format"""
     return date.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Inserting data to DB like MySQL, Postgres, etc for a timestamp without timezone column requires a valid timestamp literal. The one that broadly use is `%Y-%m-%d %H:%M:%S` format.

We've been facing many cases like that and this feature will help us to not write the same code to convert a Python date/datetime object to `%Y-%m-%d %H:%M:%S` format again and again.